### PR TITLE
https image sources and links for flickr and dribbble

### DIFF
--- a/includes/sources/dribbble.php
+++ b/includes/sources/dribbble.php
@@ -127,7 +127,7 @@ class media_manager_plus_source_dribbble extends media_manager_plus_source {
 					'id'        => $shot->id,
 					'full'      => ( isset( $shot->image_400_url ) ? $shot->image_400_url : $shot->image_url ),
 					'thumbnail' => $shot->image_teaser_url,
-					'link'      => $shot->url,
+					'link'      => set_url_scheme( $shot->url, 'https' ),
 					'caption'   => ( isset( $shot->title ) ? $this->filter_text( $shot->title ) : '' )
 				);
 			}

--- a/includes/sources/flickr.php
+++ b/includes/sources/flickr.php
@@ -132,9 +132,9 @@ class media_manager_plus_source_flickr extends media_manager_plus_source {
 			foreach ( $images->photos->photo as $photo ) {
 				$new_images[] = array(
 					'id'        => $photo->id,
-					'full'      => 'http://farm' . $photo->farm . '.static.flickr.com/' . $photo->server . '/' . $photo->id . '_' . $photo->secret . '_b.jpg',
-					'thumbnail' => 'http://farm' . $photo->farm . '.static.flickr.com/' . $photo->server . '/' . $photo->id . '_' . $photo->secret . '_q.jpg',
-					'link'      => 'http://www.flickr.com/photos/' . $photo->owner . '/' . $photo->id,
+					'full'      => '//farm' . $photo->farm . '.static.flickr.com/' . $photo->server . '/' . $photo->id . '_' . $photo->secret . '_b.jpg',
+					'thumbnail' => '//farm' . $photo->farm . '.static.flickr.com/' . $photo->server . '/' . $photo->id . '_' . $photo->secret . '_q.jpg',
+					'link'      => 'https://secure.flickr.com/photos/' . $photo->owner . '/' . $photo->id,
 					'caption'   => ( isset( $photo->title ) ? $this->filter_text( $photo->title ) : '' )
 				);
 			}


### PR DESCRIPTION
flickr and dribbble are 100% https ready with this
instagram, 500px do not support SSL
